### PR TITLE
Bugfix: baseEnv is used before being declared

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = {
         const parsedEnv = config(configOptions)
         const quasarEnv = {}
         for (const key in parsedEnv) {
-            if (baseEnv.hasOwnProperty(key)) {
+            if (parsedEnv.hasOwnProperty(key)) {
                 quasarEnv[key] = JSON.stringify(parsedEnv[key])
             }
         }


### PR DESCRIPTION
I tried using this but an error is being thrown on the offending line.
I think this was just a typo. `baseEnv` was used instead of `parsedEnv`.